### PR TITLE
Add `getBroadcastAddresses` to tools.js

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -45,6 +45,36 @@ function getOwnAddress(ip) {
 }
 
 /**
+ * Gets an array of all valid IPv4 broadcast addresses this host can send to
+ * @returns {string[]}
+ */
+function getBroadcastAddresses() {
+	// enumerate interfaces
+	const net = os.networkInterfaces();
+	const broadcastAddresses = Object.keys(net)
+		// flatten the array structure
+		.map(k => net[k])
+		.reduce((prev, cur) => prev.concat(cur), [])
+		// only use external IPv4 ones
+		.filter(add => !add.internal && add.family === "IPv4")
+		// extract address and subnet as number array
+		.map(k => ({
+			address: k.address.split(".").map(num => +num),
+			netmask: k.netmask.split(".").map(num => +num),
+		}))
+		// broadcast is address OR (not netmask)
+		.map(add => {
+			return add.address.map((val, i) => (val | ~add.netmask[i]) & 0xff);
+		})
+		// ignore unconnected ones
+		.filter(add => add[0] !== 169)
+		// turn the address into a string again
+		.map(a => `${a[0]}.${a[1]}.${a[2]}.${a[3]}`)
+		;
+	return broadcastAddresses;
+}
+
+/**
  * Test TCP port of IP address.
  *
  * This function tries to open given TCP port and if onConnect and onReceive are defined, the user can send some data in onConnect and to check it in onReceive.
@@ -689,17 +719,18 @@ function getLocationDesc(device, locationUrl, callback) {
 }
 
 
-const words = require(__dirname + '/../admin/words.js');
-
-exports.getLocationDesc   = getLocationDesc;
-exports.getOwnAddress     = getOwnAddress;
-exports.testPort          = testPort;
-exports.testSerialPort    = testSerialPort;
-exports.getNextInstanceID = getNextInstanceID;
-exports.findInstance      = findInstance;
-exports.checkEnumName     = checkEnumName;
-exports.httpGet           = httpGet;
-exports.ssdpScan          = ssdpScan;
-exports.udpScan           = udpScan;
-exports.translate         = require(__dirname + '/../admin/words.js').translate;
-exports.words             = require(__dirname + '/../admin/words.js').words;
+module.exports = {
+    getBroadcastAddresses,
+    getLocationDesc,
+    getOwnAddress,
+    testPort,
+    testSerialPort,
+    getNextInstanceID,
+    findInstance,
+    checkEnumName,
+    httpGet,
+    ssdpScan,
+    udpScan,
+    translate: require('../admin/words.js').translate,
+    words: require('../admin/words.js').words,
+};


### PR DESCRIPTION
Something like this method should be centralized instead of implementing it in the single methods or adapter discoveries. I'll be using it in the discovery for g-homa and in a similar way it's already in the milight discovery.