### PR TITLE
Use literal paths for require without `__dirname`

### DIFF
--- a/lib/adapters/bosesoundtouch.js
+++ b/lib/adapters/bosesoundtouch.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 function addbosesoundtouch(ip, device, options, callback) {
     var instance = tools.findInstance(options, 'bosesoundtouch', function (obj) {
         if (obj && obj.native && obj.native.address === ip) {

--- a/lib/adapters/broadlink.js
+++ b/lib/adapters/broadlink.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 var dgram = require('dgram');
 
 function getType(devType) {

--- a/lib/adapters/chromecast.js
+++ b/lib/adapters/chromecast.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function addChromecast(ip, device, options, callback) {
     var ownIp = tools.getOwnAddress(ip);

--- a/lib/adapters/cloud.js
+++ b/lib/adapters/cloud.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ignore1, ignore2, options, callback) {
     // options.newInstances

--- a/lib/adapters/daikin.js
+++ b/lib/adapters/daikin.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function addDaikin(ip, device, data, options, callback) {
     var foundNew = false;

--- a/lib/adapters/deconz.js
+++ b/lib/adapters/deconz.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function addDeconz(ip, device, options, callback) {
 

--- a/lib/adapters/denon.js
+++ b/lib/adapters/denon.js
@@ -1,5 +1,5 @@
 'use strict';
-const tools = require(__dirname + '/../tools.js');
+const tools = require('../tools.js');
 
 function addInstance(ip, device, options, name, manufacturer, callback) {
      let instance = tools.findInstance(options, 'denon', obj => obj.native.ip === ip);

--- a/lib/adapters/ekey.js
+++ b/lib/adapters/ekey.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 var dgram = require('dgram');
 
 function detect(ip, device, options, callback) {

--- a/lib/adapters/epson_stylus_px830.js
+++ b/lib/adapters/epson_stylus_px830.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 // based on miele
 var adapterName = 'epson_stylus_px830';
 var reIsEpsonPX830 = /<div class='tvboxlarge'>Epson Stylus Photo PX830<\/div>/;

--- a/lib/adapters/fhem.js
+++ b/lib/adapters/fhem.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ip, device, options, callback) {
     // options.newInstances

--- a/lib/adapters/firetv.js
+++ b/lib/adapters/firetv.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 var adapterName = 'firetv';
 

--- a/lib/adapters/flot.js
+++ b/lib/adapters/flot.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ignore1, ignore2, options, callback) {
     // options.newInstances

--- a/lib/adapters/fronius.js
+++ b/lib/adapters/fronius.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function addDevice(ip, device, options, native, callback) {
     var instance = tools.findInstance(options, 'fronius', function (obj) {

--- a/lib/adapters/hass.js
+++ b/lib/adapters/hass.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ip, device, options, callback) {
     // options.newInstances

--- a/lib/adapters/history.js
+++ b/lib/adapters/history.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ignore1, ignore2, options, callback) {
     // options.newInstances

--- a/lib/adapters/hm-rega.js
+++ b/lib/adapters/hm-rega.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ip, device, options, callback) {
     // options.newInstances

--- a/lib/adapters/hm-rpc.js
+++ b/lib/adapters/hm-rpc.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ip, device, options, callback) {
     // options.newInstances

--- a/lib/adapters/homepilot.js
+++ b/lib/adapters/homepilot.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 // based on miele
 var adapterName = 'homepilot';
 var reIsHomepilot = /<h1 id="form-container-automation-conflict-detection-title-resolve">/;

--- a/lib/adapters/hue.js
+++ b/lib/adapters/hue.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function addHue(ip, device, options, callback) {
     var instance = tools.findInstance(options, 'hue', function (obj) {

--- a/lib/adapters/influxdb.js
+++ b/lib/adapters/influxdb.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ip, device, options, callback) {
     // options.newInstances

--- a/lib/adapters/javascript.js
+++ b/lib/adapters/javascript.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ignore1, ignore2, options, callback) {
     // options.newInstances

--- a/lib/adapters/knx.js
+++ b/lib/adapters/knx.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 var dgram = require('dgram');
 
 function detect(ip, device, options, callback) {

--- a/lib/adapters/landroid.js
+++ b/lib/adapters/landroid.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function addDevice(ip, device, options, callback) {
 

--- a/lib/adapters/lgtv.js
+++ b/lib/adapters/lgtv.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 var dgram = require('dgram');
 
 function addInstance(ip, device, options, callback) {

--- a/lib/adapters/lightify.js
+++ b/lib/adapters/lightify.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 var adapterName = 'lightify';
 

--- a/lib/adapters/loxone.js
+++ b/lib/adapters/loxone.js
@@ -1,6 +1,6 @@
 ﻿'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 var adapterName = 'loxone';
 var portRegex = /<presentationURL>https?:\/\/[^:]+:(\d+)[^\d<]*<\/presentationURL>/

--- a/lib/adapters/maxcube.js
+++ b/lib/adapters/maxcube.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 var dgram = require('dgram');
 
 function browse(ip, cb) {

--- a/lib/adapters/megad.js
+++ b/lib/adapters/megad.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function addMegaDDevice(ip, device, options, native, callback) {
     var instance = tools.findInstance(options, 'megad', function (obj) {

--- a/lib/adapters/miele.js
+++ b/lib/adapters/miele.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 var adapterName = 'miele';
 //var reIsMiele = /^<\?xml[\s\S]*?<DEVICES>[\s\S]*?<\/DEVICES>/;

--- a/lib/adapters/mihome.js
+++ b/lib/adapters/mihome.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 var dgram = require('dgram');
 
 function listen(ip, cb) {

--- a/lib/adapters/mobile.js
+++ b/lib/adapters/mobile.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ignore1, ignore2, options, callback) {
     // options.newInstances

--- a/lib/adapters/musiccast.js
+++ b/lib/adapters/musiccast.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 var reyxcControl = /<yamaha:X_yxcControlURL>*.YamahaExtendedControl.*<\/yamaha:X_yxcControlURL>/i;
 var reFriendlyName = /<friendlyName>([^<]*)<\/friendlyName>/;

--- a/lib/adapters/mysensors.js
+++ b/lib/adapters/mysensors.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 var baudRatesGlobal = [
     9600,
     38400,

--- a/lib/adapters/nut.js
+++ b/lib/adapters/nut.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ip, device, options, callback) {
     'use strict';

--- a/lib/adapters/openhab.js
+++ b/lib/adapters/openhab.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ip, device, options, callback) {
     // options.newInstances

--- a/lib/adapters/ping.js
+++ b/lib/adapters/ping.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 // just check if IP exists
 function detect(ip, device, options, callback) {

--- a/lib/adapters/rflink.js
+++ b/lib/adapters/rflink.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(comName, device, options, callback) {
     // options.newInstances

--- a/lib/adapters/samsung.js
+++ b/lib/adapters/samsung.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function addInstance(ip, device, options, meta, callback) {
     

--- a/lib/adapters/sonnen.js
+++ b/lib/adapters/sonnen.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const tools = require(__dirname + '/../tools.js');
+const tools = require('../tools.js');
 
 function addInstance(ip, device, options, native, callback) {
     let instance = tools.findInstance(options, 'sonnen', obj => obj.native.ip === ip || obj.native.ip === device._name);

--- a/lib/adapters/sonos.js
+++ b/lib/adapters/sonos.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function insertDevice(options, instance, fromOldInstances, ip, name, room) {
     // find unique name

--- a/lib/adapters/sql.js
+++ b/lib/adapters/sql.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ip, device, options, callback) {
     // options.newInstances

--- a/lib/adapters/sql_sqlite.js
+++ b/lib/adapters/sql_sqlite.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ignore1, ignore2, options, callback) {
     // options.newInstances

--- a/lib/adapters/squeezebox.js
+++ b/lib/adapters/squeezebox.js
@@ -1,6 +1,6 @@
 ﻿'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ip, device, options, callback) {
     // options.newInstances

--- a/lib/adapters/tr-064.js
+++ b/lib/adapters/tr-064.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ip, device, options, callback) {
     // options.newInstances

--- a/lib/adapters/vis.js
+++ b/lib/adapters/vis.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ignore1, ignore2, options, callback) {
     // options.newInstances

--- a/lib/adapters/web.js
+++ b/lib/adapters/web.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(ignore1, ignore2, options, callback) {
     // options.newInstances

--- a/lib/adapters/wifilight.js
+++ b/lib/adapters/wifilight.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const tools = require(__dirname + '/../tools.js');
+const tools = require('../tools.js');
 
 const adapterName = 'wifilight';
 

--- a/lib/adapters/yamaha.js
+++ b/lib/adapters/yamaha.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const tools = require(__dirname + '/../tools.js');
+const tools = require('../tools.js');
 
 const reName = /^<\?xml.*Unit_Name="(.*?)".*YamahaRemoteControl/;
 

--- a/lib/adapters/zwave.js
+++ b/lib/adapters/zwave.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var tools = require(__dirname + '/../tools.js');
+var tools = require('../tools.js');
 
 function detect(comName, device, options, callback) {
     // options.newInstances

--- a/lib/methods/ping.js
+++ b/lib/methods/ping.js
@@ -10,7 +10,7 @@ let ownIPs = [];
 
 function pingAll(self) {
     dns  = dns  || require('dns');
-    ping = ping || require(__dirname + '/ping/ping.js');
+    ping = ping || require('./ping/ping.js');
     os   = os   || require('os');
     Netmask = Netmask || require('netmask').Netmask;
     

--- a/main.js
+++ b/main.js
@@ -11,7 +11,7 @@
 /* jshint strict:false */
 /* jslint node: true */
 'use strict';
-var utils    = require(__dirname + '/lib/utils'); // Get common adapter utils
+var utils    = require('./lib/utils'); // Get common adapter utils
 var adapter  = new utils.Adapter('discovery');
 var fs       = require('fs');
 var dns      = require('dns');


### PR DESCRIPTION
This way, VSCode can provide syntax help. Require paths are relative to the current directory anyways, so there's no need for `__dirname` and string concatenation.