### PR TITLE
fix upnp

### DIFF
--- a/lib/methods/upnp.js
+++ b/lib/methods/upnp.js
@@ -14,7 +14,7 @@ function discoverUpnp(self) {
         return;
     }
 
-    const client = new UPnPClient();
+    let client = new UPnPClient();
     const ips = {};
 
     self.close = function() {


### PR DESCRIPTION
fix type because of
```
2018-08-07 20:05:08.342 - error: Caught by controller[0]: TypeError: Assignment to constant variable.
2018-08-07 20:05:08.351 - error: Caught by controller[0]: at Method.self.close (/opt/iobroker/node_modules/iobroker.discovery/lib/methods/upnp.js:23:20)
2018-08-07 20:05:08.352 - error: Caught by controller[0]: at Timeout._onTimeout (/opt/iobroker/node_modules/iobroker.discovery/main.js:547:22)
2018-08-07 20:05:08.353 - error: Caught by controller[0]: at ontimeout (timers.js:386:11)
2018-08-07 20:05:08.353 - error: Caught by controller[0]: at tryOnTimeout (timers.js:250:5)
2018-08-07 20:05:08.353 - error: Caught by controller[0]: at Timer.listOnTimeout (timers.js:214:5)
2018-08-07 20:05:08.353 - error: host.ioBroker-Pi-Moritz instance system.adapter.discovery.0 terminated with code 0 (OK)
```