### PR TITLE
Detection of Velux KLF-200 for iobroker.klf200 adapter changed

### DIFF
--- a/lib/adapters/klf200.js
+++ b/lib/adapters/klf200.js
@@ -1,50 +1,69 @@
 'use strict';
 
 const tools = require('../tools.js');
-const url = require('url');
-// based on epson_stylus_px380
+const dns = require('dns');
 const adapterName = 'klf200';
 
-function detect(ip, device, options, callback) {
-    if (device._source !== 'ping') return callback(null, false, ip);
+function startsWithVELUX_KLF_LAN(str) {
+    return /^VELUX_KLF_LAN_/.test(str);
+}
 
-    tools.httpGet('http://' + ip + '/languages/de.json', 1000, (err, data) => {
-        if (!err && data) {
-            try {
-                data = JSON.parse(data);
-            } catch (e) {
-                data = {};
+function isHttpTcpLocal(str) {
+    return /\._http\._tcp\.local$/.test(str);
+}
+
+function addInstance(ip, hostname, device, options, callback) {
+    // Try to find an existing instance for this IP
+    const instance = tools.findInstance(options, adapterName, obj =>
+        obj && obj.native && (obj.native.host === ip || obj.native.host.localeCompare(hostname, undefined, {sensitivity: 'base'}) === 0));
+
+    if (!instance) {
+        const id = tools.getNextInstanceID(adapterName, options);
+        options.newInstances.push({
+            _id: id,
+            common: {
+                name: adapterName
+            },
+            native: {
+                host: hostname,
+                password: '',
+                enableAutomaticReboot: false,
+                automaticRebootCronTime: '0 3 * * *',
+            },
+            comment: {
+                add: [hostname, ip]
             }
-            if ('KLF 200' === data['auth.pageTitle']) {
-                let instance = tools.findInstance (options, adapterName, obj => {
-                    const hostUrl = url.parse(obj.native.host);
-                    return (hostUrl.hostname === ip || hostUrl.hostname.localeCompare(device._name, undefined, {sensitivity: 'base'}) === 0);
-                });
-                if (!instance) {
-                    const name = device._name ? device._name : ip;
-                    instance = {
-                        _id: tools.getNextInstanceID (adapterName, options),
-                        common: {
-                            name: adapterName,
-                            title: 'KLF-200'
-                        },
-                        native: {
-                            'host': 'http://' + name,
-                            'password': 'velux123',
-                            'pollInterval': 60
-                        },
-                        comment: {
-                            add: [name, ip]
-                        }
-                    };
-                    options.newInstances.push (instance);
-                    return callback (null, true, ip);
-                }
-            }
+        });
+        callback(true);
+    } else {
+        callback(false);
+    }
+}
+
+function detect(ip, device, options, callback) {
+
+    function fail() {
+        callback && callback(null, false, ip);
+        callback = null;
+    }
+
+    if (!device._mdns 
+        || !device._mdns.PTR
+        || !(startsWithVELUX_KLF_LAN(device._mdns.data))
+        || !(isHttpTcpLocal(device._mdns.data))
+    ) return fail();
+
+    dns.lookupService(ip, 51200, (err, hostname) => {
+        if (err) {
+            return fail();
         }
-        callback(null, false, ip);
+
+        addInstance(ip, hostname, device, options, callback);
     });
 }
 
-exports.detect = detect;
-exports.type = ['ip'];
+module.exports = {
+    detect,
+    type: ['mdns'],
+    timeout: 1500
+};

--- a/lib/adapters/klf200.js
+++ b/lib/adapters/klf200.js
@@ -9,7 +9,7 @@ function startsWithVELUX_KLF_LAN(str) {
 }
 
 function isHttpTcpLocal(str) {
-    return /\._http\._tcp\.local$/.test(str);
+    return /^_http\._tcp\.local$/.test(str);
 }
 
 function addInstance(ip, hostname, device, options, callback) {
@@ -36,6 +36,7 @@ function addInstance(ip, hostname, device, options, callback) {
         });
         callback(true);
     } else {
+        options.log.debug(`Instance for KLF-200 device for host ${hostname} at ${ip} already exists.`);
         callback(false);
     }
 }
@@ -47,17 +48,28 @@ function detect(ip, device, options, callback) {
         callback = null;
     }
 
+    options.log.debug(`Trying to detect KLF-200 using the following device information: ${JSON.stringify(device)} at IP ${ip}.`);
+
     if (!device._mdns 
         || !device._mdns.PTR
-        || !(startsWithVELUX_KLF_LAN(device._mdns.data))
-        || !(isHttpTcpLocal(device._mdns.data))
-    ) return fail();
+        || !(isHttpTcpLocal(device._mdns.PTR.data))
+        || !device._mdns.PTR.datax
+        || !Array.isArray(device._mdns.PTR.datax)
+        // Check if the array datax contains a VELUX_KLF_LAN entry by first mapping every entry to true/false by checking the text
+        // and then reduce the true/false values to a single true/false value (true, if at least on entry matched the pattern).
+        || !(device._mdns.PTR.datax.map(x => startsWithVELUX_KLF_LAN(x)).reduce((prev, curr) => prev || curr, false))
+    ) {
+        options.log.debug(`IP ${ip} not recognized as KLF-200 device.`);
+        return fail();
+    }
 
     dns.lookupService(ip, 51200, (err, hostname) => {
         if (err) {
+            options.log.debug(`Error ${err} during lookup of hostname for IP ${ip}.`);
             return fail();
         }
 
+        options.log.debug(`KLF-200 device detected at ${hostname} (${ip}).`);
         addInstance(ip, hostname, device, options, callback);
     });
 }


### PR DESCRIPTION
The adapter iobroker.klf200 supports the new firmware beginning with v1.x. Due to the new firmware the old detection doesn't work anymore. The new detection works over mDns and is officially documented in the latest API documentation (see https://www.velux.com/klf200 for more information).