### PR TITLE
Add: frontier_silicon.js, sma-em.js, speedwire.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ admin/i18n/*/flat.txt
 .vscode
 ioBroker.discovery.iml
 package-lock.json
+
+# ioBroker dev-server
+.dev-server/

--- a/lib/adapters/frontier_silicon.js
+++ b/lib/adapters/frontier_silicon.js
@@ -17,7 +17,7 @@ function addInstance(ip, device, options) {
                 PIN: '1234'
             },
             comment: {
-                add: 'Frontier UNDOK Device - ' + ip
+                add: `Frontier UNDOK Device ${device._name} (${ip})`
             }
         };
         options.newInstances.push(instance);
@@ -31,6 +31,9 @@ function detect(ip, device, options, callback) {
 
     device._upnp.forEach(upnp => {
         if (!foundInstance && upnp.ST && upnp.ST === 'urn:schemas-frontier-silicon-com:undok:fsapi:1') {
+            if (upnp['SPEAKER-NAME']) {
+                device._name = upnp['SPEAKER-NAME'];
+            }
             if (addInstance(ip, device, options)) {
                 foundInstance = true;
             }

--- a/lib/adapters/frontier_silicon.js
+++ b/lib/adapters/frontier_silicon.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const tools = require('../tools.js');
+
+function addInstance(ip, device, options) {
+    let instance = tools.findInstance(options, 'frontier_silicon', obj => obj.native.ip === ip);
+
+    if (!instance) {
+        const id = tools.getNextInstanceID('frontier_silicon', options);
+        instance = {
+            _id: id,
+            common: {
+                name: 'frontier_silicon'
+            },
+            native: {
+                IP: ip
+            },
+            comment: {
+                add: 'Frontier UNDOK Device - ' + ip
+            }
+        };
+        options.newInstances.push(instance);
+        return true;
+    }
+    return false;
+}
+
+function detect(ip, device, options, callback) {
+    let foundInstance = false;
+
+    device._upnp.forEach(upnp => {
+        if (!foundInstance && upnp.ST && upnp.ST === 'urn:schemas-frontier-silicon-com:undok:fsapi:1') {
+            if (addInstance(ip, device, options)) {
+                foundInstance = true;
+            }
+        }
+    });
+
+    callback(null, foundInstance, ip);
+}
+
+exports.detect = detect;
+exports.type = ['upnp'];
+exports.timeout = 500;

--- a/lib/adapters/frontier_silicon.js
+++ b/lib/adapters/frontier_silicon.js
@@ -13,7 +13,8 @@ function addInstance(ip, device, options) {
                 name: 'frontier_silicon'
             },
             native: {
-                IP: ip
+                IP: ip,
+                PIN: '1234'
             },
             comment: {
                 add: 'Frontier UNDOK Device - ' + ip

--- a/lib/adapters/frontier_silicon.js
+++ b/lib/adapters/frontier_silicon.js
@@ -17,7 +17,7 @@ function addInstance(ip, device, options) {
                 PIN: '1234'
             },
             comment: {
-                add: `Frontier UNDOK Device ${device._name} (${ip})`
+                add: `Frontier Smart Device ${device._name} (${ip})`
             }
         };
         options.newInstances.push(instance);
@@ -33,6 +33,8 @@ function detect(ip, device, options, callback) {
         if (!foundInstance && upnp.ST && upnp.ST === 'urn:schemas-frontier-silicon-com:undok:fsapi:1') {
             if (upnp['SPEAKER-NAME']) {
                 device._name = upnp['SPEAKER-NAME'];
+            } else {
+                device._name = 'UNDOK';
             }
             if (addInstance(ip, device, options)) {
                 foundInstance = true;

--- a/lib/adapters/sma-em.js
+++ b/lib/adapters/sma-em.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const tools = require('../tools.js');
+const dgram = require('dgram');
+const adapterName = 'sma-em';
+const MULTICAST_PORT = 9522;
+const MULTICAST_IP = '239.12.255.254';
+const EM_TIMEOUT = 2000; // longest interval between EM multicasts is 1000 ms
+const protocol_points = {
+    'SMASusyID': {name: 'SMA Device SUSy-ID', addr: 18, length: 2, type: 'number', unit: ''},
+    'SMASerial': {name: 'SMA Device Serial Number', addr: 20, length: 4, type: 'number', unit: ''}
+};
+
+
+let client = null;
+
+function addInstance(ip, device, options) {
+    let instance = tools.findInstance (options, adapterName, obj => obj.native.EMIP === ip);
+
+    if (instance) {
+        options.log.debug(`sma-em adapter already present for Energy Meter IP ${ip}`);
+    } else {
+        instance = {
+            _id: tools.getNextInstanceID(adapterName, options),
+            common: {
+                name: adapterName,
+                title: `SMA Energy Meter`
+            },
+            native: {
+                EMIP: ip,
+                OIP: '0.0.0.0'
+            },
+            comment: {
+                add: [`SMA Energy Meter Device  ${device._name} (${ip})`]
+            }
+        };
+        options.newInstances.push(instance);
+        options.log.debug(`New Energy Meter ${device._name} with IP ${ip} detected.`);
+        return true;
+    }
+    return false;
+}
+
+function detect(ip, device, options, callback) {
+    // options.newInstances
+    // options.existingInstances
+    // device - additional info about device
+    // options.log - logger
+
+    options.log.debug(`Detecting SMA Energy Meters broadcasting on ${MULTICAST_IP}/${MULTICAST_PORT}...`);
+    // Listen for EM broadcasts until timeout
+    client = dgram.createSocket({ type: 'udp4', reuseAddr: true });
+
+    client.on('error', err => {
+        options.log.error(`SMA-EM rxSocket error:${err.stack}`);
+        cleanup(ip, callback, false);
+        callback = null;
+    });
+
+    client.on('message', (message, remote) => {
+        options.log.debug(`UDP datagram from ${remote.address}:${remote.port}`);
+        if (check_message_type(message) === false)
+            return; // discard message if not EM protocol
+
+        const ser = message.readUIntBE(protocol_points['SMASerial'].addr, protocol_points['SMASerial'].length);
+        const ser_str = ser.toString();
+        // determine device type
+        const susy = message.readUIntBE(protocol_points['SMASusyID'].addr, protocol_points['SMASusyID'].length);
+
+        let dev_descr = ('Unkown Energy Meter device S/N: ' + ser_str);
+        if (susy == 372  || susy == 501) {
+            dev_descr = ('Sunny Home Manager 2.0 S/N: ' + ser_str);
+        } 
+        if (susy == 349) {
+            dev_descr = ('SMA Energy Meter 2.0 S/N: ' + ser_str);
+        } 
+        if (susy == 270) {
+            // eslint-disable-next-line no-unused-vars
+            dev_descr = ('SMA Energy Meter 1.0 S/N: ' + ser_str);
+        }
+        device._name = dev_descr;
+
+        addInstance(remote.address, device, options);
+    });
+
+
+    // Bind socket to the multicast address on all ipv4 devices except localhost
+    client.bind(MULTICAST_PORT, () => {
+        for (const dev of findIPv4IPs()) {
+            options.log.debug(`Listen via UDP on Device ${dev.name} with IP ${dev.ipaddr} on Port ${MULTICAST_PORT} for Multicast IP ${MULTICAST_IP}`);
+            client.addMembership(MULTICAST_IP, dev.ipaddr);
+        }
+    });
+
+    // stop listening for Energy Meters if timeout reached
+    setTimeout(() => {
+        options.log.debug('EM timeout reached');
+        cleanup(ip, callback, false);
+        callback = null;
+    }, EM_TIMEOUT);
+}
+
+function cleanup(ip, callback, callbackResult) {
+    if (client) {
+        client.close(() =>
+            callback && callback(null, callbackResult, ip));
+
+        client = null;
+    } else {
+        callback && callback(null, callbackResult, ip);
+    }
+}
+
+function findIPv4IPs() {
+    // Get all network devices
+    const ifaces = require('os').networkInterfaces();
+    const net_devs = [];
+
+    for (const dev in ifaces) {
+        // eslint-disable-next-line no-prototype-builtins
+        if (ifaces.hasOwnProperty(dev)) {
+            
+            // Read IPv4 address properties of each device by filtering for the IPv4 external interfaces
+            ifaces[dev].forEach(details => {
+                if (!details.internal && details.family === 'IPv4') {
+                    net_devs.push({name: dev, ipaddr: details.address});
+                }
+            });
+        }
+    }
+    return net_devs;
+}
+
+function check_message_type(message) {
+    // Check SMA ident string at the first 0 bytes
+    if(message.toString('ascii', 0, 3) !=  'SMA')
+        return false;
+
+    // Check protocol type
+    if(message.readUInt16BE(16) != 0x6069)
+        return false;
+
+    return true;
+}
+
+
+exports.detect = detect;
+exports.type = ['once'];     // SMA Energy Meters send out multicast messages on regular intervals 
+exports.timeout = EM_TIMEOUT + 100; // Make sure that internal timeout strikes first

--- a/lib/adapters/sma-em.js
+++ b/lib/adapters/sma-em.js
@@ -10,7 +10,7 @@ const protocol_points = {
     'SMASusyID': {name: 'SMA Device SUSy-ID', addr: 18, length: 2, type: 'number', unit: ''},
     'SMASerial': {name: 'SMA Device Serial Number', addr: 20, length: 4, type: 'number', unit: ''}
 };
-
+const debug = false;
 
 let client = null;
 
@@ -18,7 +18,7 @@ function addInstance(ip, device, options) {
     let instance = tools.findInstance (options, adapterName, obj => obj.native.EMIP === ip);
 
     if (instance) {
-        options.log.debug(`sma-em adapter already present for Energy Meter IP ${ip}`);
+        if (debug) options.log.debug(`sma-em adapter already present for Energy Meter IP ${ip}`);
     } else {
         instance = {
             _id: tools.getNextInstanceID(adapterName, options),
@@ -35,19 +35,22 @@ function addInstance(ip, device, options) {
             }
         };
         options.newInstances.push(instance);
-        options.log.debug(`New Energy Meter ${device._name} with IP ${ip} detected.`);
+        if (debug) options.log.debug(`New Energy Meter ${device._name} with IP ${ip} detected.`);
         return true;
     }
     return false;
 }
 
 function detect(ip, device, options, callback) {
+
+    if (debug) options.log.debug('Detecting sma-em devices...');
+
     // options.newInstances
     // options.existingInstances
     // device - additional info about device
     // options.log - logger
 
-    options.log.debug(`Detecting SMA Energy Meters broadcasting on ${MULTICAST_IP}/${MULTICAST_PORT}...`);
+    // options.log.debug(`Detecting SMA Energy Meters broadcasting on ${MULTICAST_IP}/${MULTICAST_PORT}...`);
     // Listen for EM broadcasts until timeout
     client = dgram.createSocket({ type: 'udp4', reuseAddr: true });
 
@@ -58,7 +61,7 @@ function detect(ip, device, options, callback) {
     });
 
     client.on('message', (message, remote) => {
-        options.log.debug(`UDP datagram from ${remote.address}:${remote.port}`);
+        if (debug) options.log.debug(`UDP datagram from ${remote.address}:${remote.port}`);
         if (check_message_type(message) === false)
             return; // discard message if not EM protocol
 
@@ -87,14 +90,14 @@ function detect(ip, device, options, callback) {
     // Bind socket to the multicast address on all ipv4 devices except localhost
     client.bind(MULTICAST_PORT, () => {
         for (const dev of findIPv4IPs()) {
-            options.log.debug(`Listen via UDP on Device ${dev.name} with IP ${dev.ipaddr} on Port ${MULTICAST_PORT} for Multicast IP ${MULTICAST_IP}`);
+            if (debug) options.log.debug(`Listen via UDP on Device ${dev.name} with IP ${dev.ipaddr} on Port ${MULTICAST_PORT} for Multicast IP ${MULTICAST_IP}`);
             client.addMembership(MULTICAST_IP, dev.ipaddr);
         }
     });
 
     // stop listening for Energy Meters if timeout reached
     setTimeout(() => {
-        options.log.debug('EM timeout reached');
+        if (debug) options.log.debug('EM timeout reached');
         cleanup(ip, callback, false);
         callback = null;
     }, EM_TIMEOUT);
@@ -118,8 +121,7 @@ function findIPv4IPs() {
 
     for (const dev in ifaces) {
         // eslint-disable-next-line no-prototype-builtins
-        if (ifaces.hasOwnProperty(dev)) {
-            
+        if (ifaces.hasOwnProperty(dev)) {            
             // Read IPv4 address properties of each device by filtering for the IPv4 external interfaces
             ifaces[dev].forEach(details => {
                 if (!details.internal && details.family === 'IPv4') {

--- a/lib/methods/speedwire.js
+++ b/lib/methods/speedwire.js
@@ -1,0 +1,169 @@
+/**
+ * Detects SMA devices which support the speedwire discovery protocol
+ * e.g. SMA grid inverters, battery inverters and control devices like Sunny Home Manager or Energy Meter
+ */
+
+// The results are devices of the form
+// {
+//     _addr: device.ip
+//     }
+// }
+//
+// the type of this discovery module is
+// type: 'speedwire'
+// To identify the adapter which handles the device, dedicated detector modules are required.
+//  
+
+
+'use strict';
+
+const tools = require('../tools.js');
+const dgram = require('dgram');
+
+const MULTICAST_PORT = 9522;
+const MULTICAST_IP = '239.12.255.254';
+const discoveryRequest =  '534d4100000402a0ffffffff0000002000000000';
+const discoveryResponse = '534d4100000402a000000001000200000001';
+
+/* @param {dgram.Socket} client The UDP socket to send the message on
+ * @param {string | Buffer} msg The message to send
+ * @param {string} ip The IP to send the message to
+ */
+function send(client, msg, ip) {
+    if (typeof msg === 'string') {
+        msg = Buffer.from(msg, 'hex');
+    }
+    client.send(msg, 0, msg.length, MULTICAST_PORT, ip);
+}
+
+/*//*
+ //* Parses a received response
+ //* @param {string} response
+ 
+function parseHelloResponse(response) {
+    try {
+        const parts = response.split(',');
+        return {
+            ip:   parts[0],
+            mac:  parts[1],
+            type: parts[2]
+        };
+    } catch (e) {
+        return null;
+    }
+}
+*/
+
+function discover(self) {
+
+    self.adapter.log.debug('Discovering devices with speedwire support...');
+
+    const result = new Map();
+    /**
+	 * Handles a response from a device
+	 * @param {Buffer} msg The received message
+	 * @param {dgram.RemoteInfo} rinfo Information about the other endpoint
+	 */
+    function handleDiscoverResponse(msg, rinfo) {
+        if (msg.length && rinfo.port === 9522) {
+            const msgAsString = msg.toString('hex');
+            if (rinfo.address && tools.startsWith(msgAsString, discoveryResponse)) {
+                result.set(rinfo.address, rinfo.address);
+                self.adapter.log.debug(`SMA Device with ${result.get(rinfo.address)} discovered...`);
+                /*
+            if (tools.startsWith(msgAsString, rinfo.address)) {
+                // The response to the 'hello' starts with the IP
+                const response = parseHelloResponse(msgAsString);
+                if (response) {
+                    result.set(response.ip, response);
+                }
+                // We want to find out some more about the device
+                // acknowledge the response
+                send(client, '+ok', rinfo.address);
+                // and ask about the server info
+                setTimeout(() => {
+                    try {
+                        send(client, 'AT+NETP\r', rinfo.address)
+                    } catch (err) {
+                        self.adapter.log.info('HF-LPB100: error sending discovery packet: ' + err);
+                    }
+                }, 100);
+            } else 
+            
+            if (result.has(rinfo.address) && tools.startsWith(msgAsString, '+ok=')) {
+                // This is the response to AT+NETP\r
+                // store it
+                result.get(rinfo.address).networkSettings = msgAsString.substr(4);
+            }
+            */
+            }
+        }
+    }
+
+    function findIPv4IPs() {
+        // Get all network devices
+        const ifaces = require('os').networkInterfaces();
+        const net_devs = [];
+    
+        for (const dev in ifaces) {
+            // eslint-disable-next-line no-prototype-builtins
+            if (ifaces.hasOwnProperty(dev)) {
+                
+                // Read IPv4 address properties of each device by filtering for the IPv4 external interfaces
+                ifaces[dev].forEach(details => {
+                    if (!details.internal && details.family === 'IPv4') {
+                        net_devs.push({name: dev, ipaddr: details.address});
+                    }
+                });
+            }
+        }
+        return net_devs;
+    }
+    
+    
+    const client = dgram.createSocket({type: 'udp4', reuseAddr: true});
+    client.bind(MULTICAST_PORT, () => { // listen on SMA multicast port        
+        client.setBroadcast(true);
+        client.setMulticastTTL(128);
+        for (const dev of findIPv4IPs()) {
+            self.log.debug(`Listen via UDP on Device ${dev.name} with IP ${dev.ipaddr} on Port ${MULTICAST_PORT} for Multicast IP ${MULTICAST_IP}`);
+            client.addMembership(MULTICAST_IP, dev.ipaddr);
+        }
+        send(client, discoveryRequest, MULTICAST_IP);
+    });
+    //            const broadcastAddresses = tools.getBroadcastAddresses();
+    // Start interview with all devices reachable under each broadcast address
+    //            broadcastAddresses.forEach(address => send(client, discoveryRequest, address));
+    //client.once('listening', () => {
+    //    send(client, discoveryRequest, MULTICAST_IP);
+    //});
+
+    client.on('error', e => self.adapter.log.console.error(e)); // log error
+    client.on('message', handleDiscoverResponse);
+
+
+
+    self.adapter.log.debug(`Send ${discoveryRequest}...`);
+
+
+    setTimeout(() => {
+        client.close();
+        //const values = result.values();
+        for (const address of result.values()) {
+            self.addDevice({
+                _addr: address,
+                _name: 'SMA Speedwire',
+            });
+            //self.adapter.log.debug(`Added Device ${address}...`);
+        }
+        self.done();
+    }, self.timeout);
+
+}
+
+module.exports = {
+    browse: discover,
+    type: 'speedwire',
+    source: 'SMA Speedwire',
+    timeout: 5000
+};

--- a/lib/methods/speedwire.js
+++ b/lib/methods/speedwire.js
@@ -24,39 +24,22 @@ const MULTICAST_PORT = 9522;
 const MULTICAST_IP = '239.12.255.254';
 const discoveryRequest =  '534d4100000402a0ffffffff0000002000000000';
 const discoveryResponse = '534d4100000402a000000001000200000001';
+const debug = false;
 
-/* @param {dgram.Socket} client The UDP socket to send the message on
+/* @param {dgram.Socket} socket The UDP socket to send the message on
  * @param {string | Buffer} msg The message to send
  * @param {string} ip The IP to send the message to
  */
-function send(client, msg, ip) {
+function send(socket, msg, ip) {
     if (typeof msg === 'string') {
         msg = Buffer.from(msg, 'hex');
     }
-    client.send(msg, 0, msg.length, MULTICAST_PORT, ip);
+    socket.send(msg, 0, msg.length, MULTICAST_PORT, ip);
 }
-
-/*//*
- //* Parses a received response
- //* @param {string} response
- 
-function parseHelloResponse(response) {
-    try {
-        const parts = response.split(',');
-        return {
-            ip:   parts[0],
-            mac:  parts[1],
-            type: parts[2]
-        };
-    } catch (e) {
-        return null;
-    }
-}
-*/
 
 function discover(self) {
 
-    self.adapter.log.debug('Discovering devices with speedwire support...');
+    if (debug) self.adapter.log.debug('Discovering devices with speedwire support...');
 
     const result = new Map();
     /**
@@ -69,33 +52,7 @@ function discover(self) {
             const msgAsString = msg.toString('hex');
             if (rinfo.address && tools.startsWith(msgAsString, discoveryResponse)) {
                 result.set(rinfo.address, rinfo.address);
-                self.adapter.log.debug(`SMA Device with ${result.get(rinfo.address)} discovered...`);
-                /*
-            if (tools.startsWith(msgAsString, rinfo.address)) {
-                // The response to the 'hello' starts with the IP
-                const response = parseHelloResponse(msgAsString);
-                if (response) {
-                    result.set(response.ip, response);
-                }
-                // We want to find out some more about the device
-                // acknowledge the response
-                send(client, '+ok', rinfo.address);
-                // and ask about the server info
-                setTimeout(() => {
-                    try {
-                        send(client, 'AT+NETP\r', rinfo.address)
-                    } catch (err) {
-                        self.adapter.log.info('HF-LPB100: error sending discovery packet: ' + err);
-                    }
-                }, 100);
-            } else 
-            
-            if (result.has(rinfo.address) && tools.startsWith(msgAsString, '+ok=')) {
-                // This is the response to AT+NETP\r
-                // store it
-                result.get(rinfo.address).networkSettings = msgAsString.substr(4);
-            }
-            */
+                if (debug) self.adapter.log.debug(`SMA Device with ${result.get(rinfo.address)} discovered...`);
             }
         }
     }
@@ -103,12 +60,10 @@ function discover(self) {
     function findIPv4IPs() {
         // Get all network devices
         const ifaces = require('os').networkInterfaces();
-        const net_devs = [];
-    
+        const net_devs = [];    
         for (const dev in ifaces) {
             // eslint-disable-next-line no-prototype-builtins
-            if (ifaces.hasOwnProperty(dev)) {
-                
+            if (ifaces.hasOwnProperty(dev)) {                
                 // Read IPv4 address properties of each device by filtering for the IPv4 external interfaces
                 ifaces[dev].forEach(details => {
                     if (!details.internal && details.family === 'IPv4') {
@@ -120,41 +75,27 @@ function discover(self) {
         return net_devs;
     }
     
-    
     const client = dgram.createSocket({type: 'udp4', reuseAddr: true});
     client.bind(MULTICAST_PORT, () => { // listen on SMA multicast port        
-        client.setBroadcast(true);
-        client.setMulticastTTL(128);
+        client.setMulticastLoopback(false);
         for (const dev of findIPv4IPs()) {
-            self.log.debug(`Listen via UDP on Device ${dev.name} with IP ${dev.ipaddr} on Port ${MULTICAST_PORT} for Multicast IP ${MULTICAST_IP}`);
+            if (debug) self.adapter.log.debug(`Listen via UDP on Device ${dev.name} with IP ${dev.ipaddr} on Port ${MULTICAST_PORT} for Multicast IP ${MULTICAST_IP}`);
             client.addMembership(MULTICAST_IP, dev.ipaddr);
         }
         send(client, discoveryRequest, MULTICAST_IP);
+        if (debug) self.adapter.log.debug(`Send discovery request: ${discoveryRequest}`);
     });
-    //            const broadcastAddresses = tools.getBroadcastAddresses();
-    // Start interview with all devices reachable under each broadcast address
-    //            broadcastAddresses.forEach(address => send(client, discoveryRequest, address));
-    //client.once('listening', () => {
-    //    send(client, discoveryRequest, MULTICAST_IP);
-    //});
 
     client.on('error', e => self.adapter.log.console.error(e)); // log error
     client.on('message', handleDiscoverResponse);
 
-
-
-    self.adapter.log.debug(`Send ${discoveryRequest}...`);
-
-
     setTimeout(() => {
-        client.close();
-        //const values = result.values();
+        client.close();        
         for (const address of result.values()) {
             self.addDevice({
                 _addr: address,
                 _name: 'SMA Speedwire',
             });
-            //self.adapter.log.debug(`Added Device ${address}...`);
         }
         self.done();
     }, self.timeout);

--- a/lib/methods/upnp.js
+++ b/lib/methods/upnp.js
@@ -33,7 +33,7 @@ function discoverUpnp(self) {
     self.setTimeout(self.timeout);
 
     multicast_client.on('advertise-alive', (headers, rinfo) => self.parseMessage(headers, 0, rinfo));
-    client.on('response', (headers, statusCode, rinfo) => self.parseMessage(headers, statusCode, rinfo));
+    client.on('response', (headers, statusCode, rinfo) => setTimeout(() => self.parseMessage(headers, statusCode, rinfo), 3000));
     multicast_client.on('response', (headers, statusCode, rinfo) => self.parseMessage(headers, statusCode, rinfo));
 
     self.parseMessage = (headers, statusCode, rinfo) => {


### PR DESCRIPTION
**NOTES:** This PR includes detector modules for the sma-em and frontier_silicon community adapters. 
Also included is a SMA speedwire method module.

The _sma-em detector_ module requires the v1.0.0 of the sma-em adapter 
(currently in "latest" see: https://github.com/iobroker-community-adapters/ioBroker.sma-em )

The _frontier_silicon detector_ module requires the v0.1.1 of the frontier_silicon adapter 
(currently in "latest" see: https://github.com/iobroker-community-adapters/ioBroker.frontier_silicon.git )
Known  problems:
 - The frontier_silicon detector has the type "upnp". Currently the upnp method does not reliably find all ssdp servers in the network (see: https://github.com/ioBroker/ioBroker.discovery/issues/278 ).
**Attention:** A possible patch to the upnp method to fix #278 is included in this PR.

- The frontier_silicon detector tries to set a default PIN for the adapter instance in order to ensure a smooth startup of the adapter. But because the PIN needs to be encrypted, startup of the instance fails and the user has to manually set the PIN. 
It would be desirable if the discovery adapter would provide an encryption function 
(see: https://github.com/ioBroker/ioBroker.discovery/issues/111 ).

The _speedwire method_ is not needed by the sma-em detector module since the latter has the type "once" and
it can discover all energy meter IPs on it's own by listening to the multicast messages 
of the energy meters just once for a period of 2 s.
However, the speedwire method might be useful for other SMA adapters like ioBroker.speedwire.
Known  problems: If instances of sma-em are already running, the speedwire method will not discover any SMA speedwire devices.
