### PR TITLE
Fix Hoymiles HMS discovery: require path and native config schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ You can execute `sudo setcap cap_net_raw+p /bin/ping` to add missing capabilitie
 -->
 ## Changelog
 ### **WORK IN PROGRESS**
+* (Eistee82) Fix Hoymiles HMS discovery: correct require path and align native config with hoymiles 0.3.4 device-array schema
 * (iobroker-bot) Adapter requires node.js >= 20 now.
 * (UncleSamSwiss) Remove obsolete squeezebox adapter
 * (GermanBluefox) Packages were updated

--- a/lib/adapters/hoymiles.js
+++ b/lib/adapters/hoymiles.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const net = require('node:net');
-const tools = require('../lib/tools');
+const tools = require('../tools.js');
 
 // Minimal Hoymiles HM protocol helpers (no external dependencies)
 function encodeVarint(value) {
@@ -57,8 +57,8 @@ function addInstance(ip, dtuSn, options) {
         },
         native: {
             enableLocal: true,
-            host: ip,
-            pollInterval: 0,
+            devices: [{ host: ip, enabled: true }],
+            dataInterval: 5,
             slowPollFactor: 6,
         },
         comment: {
@@ -69,7 +69,15 @@ function addInstance(ip, dtuSn, options) {
 }
 
 function detect(ip, device, options, callback) {
-    if (tools.findInstance(options, 'hoymiles', obj => obj.native.host === ip)) {
+    const isDuplicate = tools.findInstance(options, 'hoymiles', obj => {
+        const devices = obj.native && obj.native.devices;
+        if (Array.isArray(devices) && devices.some(d => d && d.host === ip)) {
+            return true;
+        }
+        // legacy v0.2.0 flat config (host as top-level native field)
+        return obj.native && obj.native.host === ip;
+    });
+    if (isDuplicate) {
         callback(null, false, ip);
         return;
     }

--- a/test/adapters/hoymiles.test.js
+++ b/test/adapters/hoymiles.test.js
@@ -1,0 +1,181 @@
+'use strict';
+
+/**
+ * Tests for the hoymiles detection file (lib/adapters/hoymiles.js).
+ *
+ * Covers the two bugs in the as-merged version (PR #386 + linter cleanup ea93fb0):
+ *
+ *   1. require path: '../lib/tools' resolves to lib/lib/tools — does not exist
+ *      and crashes module load on first discovery scan.
+ *   2. native config schema: produced { host, pollInterval } — but hoymiles
+ *      adapter v0.3.x expects { devices: [{ host, enabled }], dataInterval }.
+ *      The adapter migration only triggers when devices is undefined; io-package.json
+ *      sets devices: [] as default, so the legacy host field is never migrated and
+ *      the adapter logs "Local connection enabled but no devices configured".
+ */
+
+// ---------------------------------------------------------------------------
+// Stub for admin/words.js — required by lib/tools.js but deleted from master
+// in 04c0ced. Without this stub the same MODULE_NOT_FOUND error occurs as in
+// the existing air-q.test.js file. Install BEFORE requiring tools.js / hoymiles.js.
+// ---------------------------------------------------------------------------
+const Module = require('node:module');
+const _origResolveFilename = Module._resolveFilename;
+const STUB_ID = '__hoymiles-test-admin-words-stub__';
+Module._resolveFilename = function (request, parent, ...rest) {
+    if (request === '../admin/words.js') {
+        return STUB_ID;
+    }
+    return _origResolveFilename.call(this, request, parent, ...rest);
+};
+require.cache[STUB_ID] = {
+    id: STUB_ID,
+    filename: STUB_ID,
+    loaded: true,
+    exports: { translate: () => '', words: {} },
+    children: [],
+    paths: [],
+};
+
+const expect = require('chai').expect;
+const net = require('node:net');
+const path = require('node:path');
+const hoymiles = require(path.join('..', '..', 'lib', 'adapters', 'hoymiles.js'));
+
+const DTU_SERIAL = '116181234567';
+
+function freshOptions() {
+    return { newInstances: [], existingInstances: [] };
+}
+
+// Build a minimal Hoymiles InfoData response: HM magic + cmd 0xa2 0x01,
+// then a length-delimited protobuf string (field 1) carrying the DTU serial.
+function buildMockInfoResponse() {
+    const sn = Buffer.from(DTU_SERIAL, 'ascii');
+    const payload = Buffer.concat([Buffer.from([0x0a, sn.length]), sn]);
+    const totalLen = 10 + payload.length;
+    const header = Buffer.alloc(10);
+    header[0] = 0x48;
+    header[1] = 0x4d; // "HM"
+    header[2] = 0xa2;
+    header[3] = 0x01; // InfoData response
+    header[4] = 0x00;
+    header[5] = 0x01;
+    header[6] = 0x00;
+    header[7] = 0x00;
+    header[8] = (totalLen >> 8) & 0xff;
+    header[9] = totalLen & 0xff;
+    return Buffer.concat([header, payload]);
+}
+
+describe('hoymiles discovery — module loading', function () {
+    it('module loads without throwing (require path is correct)', function () {
+        expect(hoymiles).to.be.an('object');
+        expect(hoymiles.detect).to.be.a('function');
+        expect(hoymiles.type).to.deep.equal(['ip']);
+    });
+});
+
+describe('hoymiles discovery — native config schema', function () {
+    it('produces device-array native shape on successful detection', function (done) {
+        const port = 10081;
+        const server = net.createServer(socket => {
+            socket.on('data', () => socket.write(buildMockInfoResponse()));
+        });
+
+        server.once('error', err => {
+            if (err.code === 'EADDRINUSE') {
+                this && this.skip ? this.skip() : done();
+                return;
+            }
+            done(err);
+        });
+
+        server.listen(port, '127.0.0.1', () => {
+            const opts = freshOptions();
+            hoymiles.detect('127.0.0.1', { _addr: '127.0.0.1' }, opts, (err, found) => {
+                server.close(() => {
+                    try {
+                        expect(err).to.be.null;
+                        expect(found).to.equal(true);
+                        expect(opts.newInstances).to.have.lengthOf(1);
+
+                        const inst = opts.newInstances[0];
+                        expect(inst.common.name).to.equal('hoymiles');
+                        expect(inst.common.title).to.include(DTU_SERIAL);
+
+                        // Bug #2: must be device-array, not flat host
+                        expect(inst.native).to.have.property('devices');
+                        expect(inst.native.devices).to.be.an('array').with.lengthOf(1);
+                        expect(inst.native.devices[0]).to.deep.equal({
+                            host: '127.0.0.1',
+                            enabled: true,
+                        });
+                        expect(inst.native).to.have.property('dataInterval', 5);
+                        expect(inst.native).to.have.property('slowPollFactor', 6);
+                        expect(inst.native).to.have.property('enableLocal', true);
+                        expect(inst.native).to.not.have.property('host');
+                        expect(inst.native).to.not.have.property('pollInterval');
+
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                });
+            });
+        });
+    });
+});
+
+describe('hoymiles discovery — duplicate prevention', function () {
+    it('skips IPs already present in an instance device array', function (done) {
+        const opts = {
+            newInstances: [
+                {
+                    _id: 'system.adapter.hoymiles.0',
+                    common: { name: 'hoymiles' },
+                    native: {
+                        enableLocal: true,
+                        devices: [{ host: '10.20.30.40', enabled: true }],
+                    },
+                },
+            ],
+            existingInstances: [],
+        };
+
+        hoymiles.detect('10.20.30.40', { _addr: '10.20.30.40' }, opts, (err, found, ip) => {
+            try {
+                expect(err).to.be.null;
+                expect(found).to.equal(false);
+                expect(ip).to.equal('10.20.30.40');
+                expect(opts.newInstances).to.have.lengthOf(1);
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    });
+
+    it('still recognises the legacy v0.2.0 flat host field', function (done) {
+        const opts = {
+            newInstances: [
+                {
+                    _id: 'system.adapter.hoymiles.0',
+                    common: { name: 'hoymiles' },
+                    native: { enableLocal: true, host: '10.20.30.41' },
+                },
+            ],
+            existingInstances: [],
+        };
+
+        hoymiles.detect('10.20.30.41', { _addr: '10.20.30.41' }, opts, (err, found) => {
+            try {
+                expect(err).to.be.null;
+                expect(found).to.equal(false);
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes two bugs in the Hoymiles discovery code merged via #386 (and styled by ea93fb0). The merged code never worked end-to-end: it crashed module load on the first scan, and the produced native config did not match the hoymiles adapter schema.

Verified end-to-end against a real Hoymiles HMS DTU on the LAN (`192.168.178.87`, SN `4143A01CEDE4`) and against a mock DTU running in `@iobroker/dev-server` — the adapter reaches `Connected to DTU` and starts its poll cycle with the discovery-supplied settings.

## Changes

**`lib/adapters/hoymiles.js`**
- Correct the `tools` require path: `'../lib/tools'` → `'../tools.js'`. The wrong path resolves to `lib/lib/tools` and crashes with `MODULE_NOT_FOUND` as soon as discovery loads the detector.
- Align the produced native config with the hoymiles 0.3.x schema:
  `{ host, pollInterval }` → `{ devices: [{ host, enabled: true }], dataInterval }`.
  The adapter reads `cfg.devices` (array of `{host, enabled}`) and `cfg.dataInterval`. Its legacy migration only triggers when `devices` is `undefined`, but `io-package.json` sets `devices: []` as default — so the legacy `host` field was never migrated and the adapter logged *"Local connection enabled but no devices configured"*.
- Update the duplicate-instance check to look inside `native.devices`, while still recognising the legacy flat `host` field.

**`test/adapters/hoymiles.test.js`** (new)
- Mocha + chai tests in the same style as the existing `test/adapters/air-q.test.js`.
- Covers: module loading (require path), device-array native shape (real TCP mock-DTU on `127.0.0.1:10081`), and duplicate prevention for both new and legacy config layouts.
- 4/4 passing locally.

**`README.md`**
- Changelog entry under `### **WORK IN PROGRESS**`.

## Relation to #401

This PR is the corrective alternative to revert PR #401. The argument behind #401 (*"adapter not yet listed at the repositories"*) is partially out of date — `iobroker.hoymiles` is listed in the **testing** repository, and the discovery code is functional after this fix. With these two lines fixed, the discovery actually does what it was supposed to from the start, and removing it would be premature.

## Breaking Changes

None. The duplicate-detection branch keeps recognising the legacy flat `host` field, so any pre-existing instance objects (none should exist yet, as the merged code never produced a working instance) remain handled.

## Test plan

- [x] Module loads without `MODULE_NOT_FOUND`
- [x] Discovery against a mock DTU produces a valid `newInstance` with the device-array schema
- [x] Duplicate prevention works for both the new and legacy native shapes
- [x] Real LAN test: real Hoymiles DTU at `192.168.178.87` (SN `4143A01CEDE4`) detected by the LAN scan
- [x] End-to-end in `@iobroker/dev-server`: hoymiles.0 logs `Connected to DTU` and starts poll cycle (`Poll cycle: every 5s, config/alarms every 6 polls`)
- [x] `npm test` unchanged vs. master (43 passing; the 1 pre-existing fail — `common.license` next to `common.licenseInformation` — is in master and not introduced here)
- [x] `npx eslint -c eslint.config.mjs lib/adapters/hoymiles.js` — 0 errors, 0 warnings
- [x] `npx @iobroker/repochecker` against the branch: `FINAL status 'OK'`. All listed errors are pre-existing master issues or fork-PR artefacts (E0019, E4005/7/26/28, E8002 — listed in the checklist as "ignore for fork PRs, resolve after merge").

## Notes for the maintainer

While preparing this fix I noticed two unrelated master-side issues that affect this repo more broadly (separate from this PR):

1. `lib/tools.js:828-829` requires `'../admin/words.js'`, but that file was deleted in `04c0ced`. As a result, every `lib/adapters/*.js` detector crashes when its module is loaded. The new test file works around this with a `Module._resolveFilename` stub (the existing `test/adapters/air-q.test.js` is also affected and currently un-runnable for the same reason).
2. The `Test and Release` workflow runs `npm run test:package`, but `package.json` only has `test`. CI on master is currently red because of this missing script.

Happy to open separate PRs for either of these if useful.