### PR TITLE
Add detection for GoodWe ET/EH/BH/BT inverters

### DIFF
--- a/lib/adapters/goodwe.js
+++ b/lib/adapters/goodwe.js
@@ -1,0 +1,153 @@
+'use strict';
+
+const tools = require('../tools.js');
+const dgram = require('node:dgram');
+
+const adapterName = 'goodwe';
+const GOODWE_UDP_PORT = 8899;
+const GOODWE_TIMEOUT = 700;
+
+// GoodWe API v1.7, 4.1: AP -> inverter "query ID info" packet.
+// Header 0xAA 0x55, from AP 0xC0 to inverter 0x7F, control 0x01, function 0x02,
+// no payload, followed by the 16 bit sum of all preceding bytes.
+const ID_INFO_REQUEST = buildIdInfoRequest();
+
+function checksum16(data, start, length) {
+    let checksum = 0;
+
+    for (let index = start; index < start + length; index++) {
+        checksum += data[index];
+    }
+
+    return checksum & 0xffff;
+}
+
+function buildIdInfoRequest() {
+    const request = Buffer.from([0xaa, 0x55, 0xc0, 0x7f, 0x01, 0x02, 0x00, 0x00, 0x00]);
+    const checksum = checksum16(request, 0, request.length - 2);
+
+    request[request.length - 2] = checksum >> 8;
+    request[request.length - 1] = checksum & 0xff;
+
+    return request;
+}
+
+function isIdInfoResponse(data) {
+    if (!Buffer.isBuffer(data) || data.length < 73) {
+        return false;
+    }
+
+    const expected = checksum16(data, 0, data.length - 2);
+    const actual = (data[data.length - 2] << 8) + data[data.length - 1];
+
+    return (
+        actual === expected &&
+        data[0] === 0xaa &&
+        data[1] === 0x55 &&
+        data[2] === 0x7f &&
+        data[3] === 0xc0 &&
+        data[4] === 0x01 &&
+        data[5] === 0x82
+    );
+}
+
+function readAscii(data, start, length) {
+    return data
+        .slice(start, start + length)
+        .toString('ascii')
+        .replace(/\0/g, '')
+        .trim();
+}
+
+function buildTitle(ip, response) {
+    const modelName = readAscii(response, 12, 10);
+    const serialNumber = readAscii(response, 38, 16);
+    const details = [modelName, serialNumber].filter(part => part).join(' ');
+
+    return details ? `GoodWe ${details} (${ip})` : `GoodWe inverter (${ip})`;
+}
+
+function addInstance(ip, response, options) {
+    const instance = tools.findInstance(options, adapterName, obj => obj.native.ipAddr === ip);
+
+    if (instance) {
+        options.log.info(`GoodWe adapter already present for IP ${ip}`);
+        return false;
+    }
+
+    options.newInstances.push({
+        _id: tools.getNextInstanceID(adapterName, options),
+        common: {
+            name: adapterName,
+            title: buildTitle(ip, response),
+        },
+        native: {
+            ipAddr: ip,
+        },
+        comment: {
+            add: ['read your GoodWe ET/EH/BH/BT inverter over the local network'],
+        },
+    });
+
+    return true;
+}
+
+function detect(ip, device, options, callback) {
+    options.log.debug(`Detecting GoodWe inverter on ${ip}...`);
+
+    const socket = dgram.createSocket('udp4');
+    let timeout = null;
+    let done = false;
+
+    function finish(found) {
+        if (done) {
+            return;
+        }
+
+        done = true;
+
+        if (timeout) {
+            clearTimeout(timeout);
+            timeout = null;
+        }
+
+        try {
+            socket.close(() => callback(null, found, ip));
+        } catch (e) {
+            options.log.debug(`GoodWe socket close failed for ${ip}: ${e}`);
+            callback(null, found, ip);
+        }
+    }
+
+    timeout = setTimeout(() => {
+        options.log.debug(`GoodWe timeout reached for ${ip}`);
+        finish(false);
+    }, GOODWE_TIMEOUT);
+
+    socket.on('error', err => {
+        options.log.debug(`GoodWe socket error for ${ip}: ${err}`);
+        finish(false);
+    });
+
+    socket.on('message', message => {
+        if (!isIdInfoResponse(message)) {
+            options.log.debug(`GoodWe ignored a non matching UDP answer from ${ip}`);
+            return;
+        }
+
+        finish(addInstance(ip, message, options));
+    });
+
+    socket.send(ID_INFO_REQUEST, GOODWE_UDP_PORT, ip, err => {
+        if (err) {
+            options.log.debug(`GoodWe request to ${ip} failed: ${err}`);
+            finish(false);
+        }
+    });
+}
+
+exports.detect = detect;
+exports.type = ['ip']; // the inverter answers on UDP only, so every reachable IP is probed
+exports.timeout = GOODWE_TIMEOUT;
+exports.buildIdInfoRequest = buildIdInfoRequest;
+exports.isIdInfoResponse = isIdInfoResponse;

--- a/test/adapters/goodwe.test.js
+++ b/test/adapters/goodwe.test.js
@@ -1,0 +1,147 @@
+'use strict';
+
+/**
+ * Tests for the GoodWe detection file (lib/adapters/goodwe.js).
+ *
+ * The inverter answers on UDP only, so the detection cannot rely on an open
+ * TCP port. A local UDP responder stands in for the inverter.
+ */
+
+const expect = require('chai').expect;
+const dgram = require('node:dgram');
+const path = require('node:path');
+const goodwe = require(path.join('..', '..', 'lib', 'adapters', 'goodwe.js'));
+
+const GOODWE_UDP_PORT = 8899;
+
+function freshOptions() {
+    return {
+        newInstances: [],
+        existingInstances: [],
+        log: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    };
+}
+
+// GoodWe API v1.7, 4.1: inverter -> AP "response ID info" packet.
+function buildIdInfoResponse(modelName, serialNumber) {
+    const response = Buffer.alloc(73);
+
+    response[0] = 0xaa;
+    response[1] = 0x55;
+    response[2] = 0x7f;
+    response[3] = 0xc0;
+    response[4] = 0x01;
+    response[5] = 0x82;
+    response.write(modelName, 12, 10, 'ascii');
+    response.write(serialNumber, 38, 16, 'ascii');
+
+    let checksum = 0;
+    for (let index = 0; index < response.length - 2; index++) {
+        checksum += response[index];
+    }
+    response[response.length - 2] = (checksum >> 8) & 0xff;
+    response[response.length - 1] = checksum & 0xff;
+
+    return response;
+}
+
+function startResponder(answerFactory) {
+    return new Promise((resolve, reject) => {
+        const socket = dgram.createSocket('udp4');
+
+        socket.on('error', reject);
+        socket.on('message', (message, remote) => {
+            const answer = answerFactory(message);
+
+            if (answer) {
+                socket.send(answer, remote.port, remote.address);
+            }
+        });
+        socket.bind(GOODWE_UDP_PORT, '127.0.0.1', () => resolve(socket));
+    });
+}
+
+function detect(options) {
+    return new Promise(resolve => {
+        goodwe.detect('127.0.0.1', {}, options, (err, found) => resolve({ err, found }));
+    });
+}
+
+describe('GoodWe detection', () => {
+    it('builds the ID info request accepted by the inverter', () => {
+        expect([...goodwe.buildIdInfoRequest()]).to.deep.equal([
+            0xaa, 0x55, 0xc0, 0x7f, 0x01, 0x02, 0x00, 0x02, 0x41,
+        ]);
+    });
+
+    it('rejects short, foreign and corrupted answers', () => {
+        const response = buildIdInfoResponse('GW10K-ET', '9010KETU231W1723');
+
+        expect(goodwe.isIdInfoResponse(response)).to.be.true;
+        expect(goodwe.isIdInfoResponse(response.slice(0, 40))).to.be.false;
+        expect(goodwe.isIdInfoResponse(Buffer.alloc(73))).to.be.false;
+
+        const corrupted = Buffer.from(response);
+        corrupted[20] = corrupted[20] ^ 0xff;
+        expect(goodwe.isIdInfoResponse(corrupted)).to.be.false;
+    });
+
+    it('creates an instance for an answering inverter', async function () {
+        this.timeout(5000);
+
+        const responder = await startResponder(() => buildIdInfoResponse('GW10K-ET', '9010KETU231W1723'));
+        const options = freshOptions();
+
+        try {
+            const { err, found } = await detect(options);
+
+            expect(err).to.be.null;
+            expect(found).to.be.true;
+            expect(options.newInstances).to.have.lengthOf(1);
+            expect(options.newInstances[0].native.ipAddr).to.equal('127.0.0.1');
+            expect(options.newInstances[0].common.name).to.equal('goodwe');
+            expect(options.newInstances[0].common.title).to.contain('GW10K-ET');
+            expect(options.newInstances[0].common.title).to.contain('9010KETU231W1723');
+        } finally {
+            responder.close();
+        }
+    });
+
+    it('ignores a device that answers something else', async function () {
+        this.timeout(5000);
+
+        const responder = await startResponder(() => Buffer.from('not a goodwe inverter'));
+        const options = freshOptions();
+
+        try {
+            const { found } = await detect(options);
+
+            expect(found).to.be.false;
+            expect(options.newInstances).to.be.empty;
+        } finally {
+            responder.close();
+        }
+    });
+
+    it('does not add a second instance for an already configured inverter', async function () {
+        this.timeout(5000);
+
+        const responder = await startResponder(() => buildIdInfoResponse('GW10K-ET', '9010KETU231W1723'));
+        const options = freshOptions();
+
+        options.existingInstances.push({
+            _id: 'system.adapter.goodwe.0',
+            common: { name: 'goodwe' },
+            native: { ipAddr: '127.0.0.1' },
+        });
+
+        try {
+            const { found } = await detect(options);
+
+            expect(found).to.be.false;
+            expect(options.newInstances).to.be.empty;
+        } finally {
+            responder.close();
+        }
+    });
+});


### PR DESCRIPTION
Adds `lib/adapters/goodwe.js` for the `goodwe` adapter (already in the latest repository).

## How it detects

GoodWe ET/EH/BH/BT inverters answer on UDP port 8899 only, so a TCP port scan never finds them. The module therefore uses `type: ['ip']` and sends the "query ID info" packet of the GoodWe API v1.7 to every reachable IP, then validates header, length and checksum of the answer before accepting the device. Model name and serial number from the answer go into the instance title.

The detected IP is stored as `native.ipAddr`, which is the field the `goodwe` adapter uses. `tools.findInstance()` prevents a second instance for an inverter that is already configured.

## Note on parallel detection

Socket and timer stay in the call scope instead of module scope. IP adapters are detected in parallel, so module level state would let one detection close the socket of another. This is the one thing that differs from `kecontact.js`, which served as the template otherwise.

## Tests

`test/adapters/goodwe.test.js` runs a local UDP responder and covers the request frame, rejection of short, foreign and corrupted answers, successful detection, a foreign device and an already configured instance.

```
npm run test:integration   # 23 passing, 5 of them new
npx eslint lib/adapters/goodwe.js   # clean
```

The request frame built by this module is byte identical to the one the `goodwe` adapter sends to real hardware.
